### PR TITLE
feat: support constant parameter values

### DIFF
--- a/calisim/data_model/simulation_data_models.py
+++ b/calisim/data_model/simulation_data_models.py
@@ -30,6 +30,7 @@ class ParameterDataType(Enum):
 	DISCRETE: str = "discrete"
 	CONTINUOUS: str = "continuous"
 	CATEGORICAL: str = "categorical"
+	CONSTANT: str = "constant"
 
 
 class ParameterModel(BaseModel):
@@ -81,6 +82,9 @@ class ParameterSpecification(BaseModel):
 
 	parameters: list[DistributionModel] | None = Field(
 		description="The parameter specification list", default=None
+	)
+	constants: dict[str, Any] | None = Field(
+		description="The constant parameter values", default=None
 	)
 
 

--- a/calisim/utils/utilities.py
+++ b/calisim/utils/utilities.py
@@ -86,8 +86,15 @@ def calibration_func_wrapper(
 	import numpy as np
 
 	parameters = []
+	constants = {}
+	if (
+		workflow.specification.parameter_spec is not None
+		and workflow.specification.parameter_spec.constants is not None
+	):
+		constants = workflow.specification.parameter_spec.constants
+
 	for theta in X:
-		parameter_set = {}
+		parameter_set = constants.copy()
 		for i, parameter_value in enumerate(theta):
 			parameter_name = parameter_names[i]
 			data_type = data_types[i]


### PR DESCRIPTION
Add support for constant parameter values in the calibration workflow.

- Added  to  enum.
- Added  dictionary to  model.
- Updated  to merge constant values with sampled variable parameters.

Closes #83