### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,6 +19,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   run-tests:
 


### PR DESCRIPTION
Potential fix for [https://github.com/Plant-Food-Research-Open/calisim/security/code-scanning/4](https://github.com/Plant-Food-Research-Open/calisim/security/code-scanning/4)

Add an explicit `permissions` block at the workflow root in `.github/workflows/test.yaml` so all jobs inherit least-privilege defaults.  
Best single fix here (without changing functionality) is:

- Set `contents: read` (needed for checkout/read repo content).
- Set `pull-requests: write` (needed for sticky PR comment step).
- Keep scope at workflow root so behavior is consistent across matrix runs and triggers.

This should be inserted after `concurrency` (or near top-level keys) before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
