### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   publish-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Plant-Food-Research-Open/calisim/security/code-scanning/2](https://github.com/Plant-Food-Research-Open/calisim/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/publish.yaml`.  
Best fix without changing functionality: set workflow-level permissions to minimal read access:

- `contents: read`

This is sufficient for `actions/checkout` and does not grant unnecessary write scopes. Place it at the top level (after `concurrency` or before `jobs`) so it applies to all jobs in this workflow unless overridden later.

No imports, methods, or dependencies are needed; this is a YAML configuration-only change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
