### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   run-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Plant-Food-Research-Open/calisim/security/code-scanning/1](https://github.com/Plant-Food-Research-Open/calisim/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/lint.yaml` at the workflow root so it applies to all jobs (current and future unless overridden). For this lint workflow, the minimal safe baseline is:

- `contents: read`

This preserves current behavior (`actions/checkout` needs repository read access) while enforcing least privilege for `GITHUB_TOKEN` and resolving the CodeQL finding. No imports, methods, or dependencies are needed—just YAML configuration in this file near the top-level keys (e.g., after `concurrency` and before `jobs`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
