### PR TITLE
Fix for Commented-out code

### DIFF
--- a/calisim/orchestration/torchx_bridge.py
+++ b/calisim/orchestration/torchx_bridge.py
@@ -28,8 +28,6 @@ def get_def(orchestration: OrchestrationModel, args: list[str]) -> specs.AppDef:
 	entrypoint = orchestration.entrypoint
 
 	args = [str(arg) for arg in args]
-	# if entrypoint == "sh" or entrypoint == "/bin/bash" and args[0] != "-c":
-	# 	args = ["-c"] + args
 
 	return specs.AppDef(
 		name=orchestration.name,


### PR DESCRIPTION
To fix this without changing functionality, remove the commented-out `if` block entirely. Since it is currently inactive, deleting it preserves runtime behavior exactly while resolving the readability issue. The best minimal fix is in `calisim/orchestration/torchx_bridge.py` within `get_def(...)`, immediately after `args = [str(arg) for arg in args]`.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._